### PR TITLE
feat: add flags to disable Helm or Kubernetes tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,43 @@ When read-only mode is enabled, the following tools are disabled:
 
 All other read-only operations remain available, including listing resources, getting logs, viewing metrics, and inspecting Helm releases.
 
+#### Tool Category Flags
+You can selectively disable entire categories of tools using these flags:
+
+**Disable Kubernetes Tools:**
+```bash
+./k8s-mcp-server --no-k8s
+```
+
+**Disable Helm Tools:**
+```bash
+./k8s-mcp-server --no-helm
+```
+
+**Combine with other flags:**
+```bash
+# Read-only mode with only Kubernetes tools (no Helm)
+./k8s-mcp-server --read-only --no-helm
+
+# Read-only mode with only Helm tools (no Kubernetes)
+./k8s-mcp-server --read-only --no-k8s
+
+# SSE mode with only Kubernetes tools
+./k8s-mcp-server --mode sse --no-helm
+
+```
+
+**Note:** You cannot use both `--no-k8s` and `--no-helm` together, as this would result in no available tools. The server will exit with an error if both flags are provided.
+
+When `--no-k8s` is enabled, all Kubernetes tools are disabled:
+- `getAPIResources`, `listResources`, `getResource`, `describeResource`
+- `getPodsLogs`, `getNodeMetrics`, `getPodMetrics`, `getEvents`
+- `createResource` (if not in read-only mode)
+
+When `--no-helm` is enabled, all Helm tools are disabled:
+- `helmList`, `helmGet`, `helmHistory`, `helmRepoList`
+- `helmInstall`, `helmUpgrade`, `helmUninstall`, `helmRollback`, `helmRepoAdd` (if not in read-only mode)
+
 ### Using the Docker Image
 
 You can also run the server using the pre-built Docker image from Docker Hub.
@@ -603,6 +640,51 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercon
        "k8s-mcp-server": {
          "command": "k8s-mcp-server",
          "args": ["--mode", "stdio", "--read-only"],
+         "env": {
+           "KUBECONFIG": "${env:HOME}/.kube/config"
+         }
+       }
+     }
+   }
+   ```
+
+   **Kubernetes Tools Only:**
+   ```json
+   {
+     "mcp.mcpServers": {
+       "k8s-mcp-server": {
+         "command": "k8s-mcp-server",
+         "args": ["--mode", "stdio", "--no-helm"],
+         "env": {
+           "KUBECONFIG": "${env:HOME}/.kube/config"
+         }
+       }
+     }
+   }
+   ```
+
+   **Helm Tools Only:**
+   ```json
+   {
+     "mcp.mcpServers": {
+       "k8s-mcp-server": {
+         "command": "k8s-mcp-server",
+         "args": ["--mode", "stdio", "--no-k8s"],
+         "env": {
+           "KUBECONFIG": "${env:HOME}/.kube/config"
+         }
+       }
+     }
+   }
+   ```
+
+   **Read-Only with Kubernetes Tools Only:**
+   ```json
+   {
+     "mcp.mcpServers": {
+       "k8s-mcp-server": {
+         "command": "k8s-mcp-server",
+         "args": ["--mode", "stdio", "--read-only", "--no-helm"],
          "env": {
            "KUBECONFIG": "${env:HOME}/.kube/config"
          }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
       - KUBECONFIG=/root/.kube/config
       - SERVER_MODE=sse # Explicitly set server mode (stdio, sse, or streamable-http)
       - SERVER_PORT=8080 # Explicitly set server port for SSE mode
-    # command: ["--read-only"] # Uncomment this line to enable read-only mode
+    # command: ["--read-only"] # Uncomment to enable read-only mode
+    # command: ["--no-k8s"] # Uncomment to disable Kubernetes tools
+    # command: ["--no-helm"] # Uncomment to disable Helm tools
+    # command: ["--read-only", "--no-helm"] # Uncomment for read-only with only Kubernetes tools
     restart: unless-stopped
     healthcheck:
       # Ensure 'curl' is installed in your Docker image (e.g., RUN apk --no-cache add curl in Dockerfile)

--- a/main.go
+++ b/main.go
@@ -29,15 +29,33 @@ func main() {
 	var mode string
 	var port string
 	var readOnly bool
+	var noK8s bool
+	var noHelm bool
 
 	flag.StringVar(&port, "port", getEnvOrDefault("SERVER_PORT", "8080"), "Server port")
 	flag.StringVar(&mode, "mode", getEnvOrDefault("SERVER_MODE", "sse"), "Server mode: 'stdio', 'sse', or 'streamable-http'")
 	flag.BoolVar(&readOnly, "read-only", false, "Enable read-only mode (disables write operations)")
+	flag.BoolVar(&noK8s, "no-k8s", false, "Disable Kubernetes tools")
+	flag.BoolVar(&noHelm, "no-helm", false, "Disable Helm tools")
 	flag.Parse()
+
+	// Validate flag combinations
+	if noK8s && noHelm {
+		fmt.Println("Error: Cannot disable both Kubernetes and Helm tools. At least one tool category must be enabled.")
+		os.Exit(1)
+	}
 
 	// Log read-only mode status
 	if readOnly {
 		fmt.Println("Starting server in read-only mode - write operations disabled")
+	}
+
+	// Log disabled tool categories
+	if noK8s {
+		fmt.Println("Kubernetes tools disabled")
+	}
+	if noHelm {
+		fmt.Println("Helm tools disabled")
 	}
 
 	// Create MCP server
@@ -62,33 +80,37 @@ func main() {
 	}
 
 	// Register Kubernetes tools
-	s.AddTool(tools.GetAPIResourcesTool(), handlers.GetAPIResources(client))
-	s.AddTool(tools.ListResourcesTool(), handlers.ListResources(client))
-	s.AddTool(tools.GetResourcesTool(), handlers.GetResources(client))
-	s.AddTool(tools.DescribeResourcesTool(), handlers.DescribeResources(client))
-	s.AddTool(tools.GetPodsLogsTools(), handlers.GetPodsLogs(client))
-	s.AddTool(tools.GetNodeMetricsTools(), handlers.GetNodeMetrics(client))
-	s.AddTool(tools.GetPodMetricsTool(), handlers.GetPodMetrics(client))
-	s.AddTool(tools.GetEventsTool(), handlers.GetEvents(client))
+	if !noK8s {
+		s.AddTool(tools.GetAPIResourcesTool(), handlers.GetAPIResources(client))
+		s.AddTool(tools.ListResourcesTool(), handlers.ListResources(client))
+		s.AddTool(tools.GetResourcesTool(), handlers.GetResources(client))
+		s.AddTool(tools.DescribeResourcesTool(), handlers.DescribeResources(client))
+		s.AddTool(tools.GetPodsLogsTools(), handlers.GetPodsLogs(client))
+		s.AddTool(tools.GetNodeMetricsTools(), handlers.GetNodeMetrics(client))
+		s.AddTool(tools.GetPodMetricsTool(), handlers.GetPodMetrics(client))
+		s.AddTool(tools.GetEventsTool(), handlers.GetEvents(client))
 
-	// Register write operations only if not in read-only mode
-	if !readOnly {
-		s.AddTool(tools.CreateOrUpdateResourceTool(), handlers.CreateOrUpdateResource(client))
+		// Register write operations only if not in read-only mode
+		if !readOnly {
+			s.AddTool(tools.CreateOrUpdateResourceTool(), handlers.CreateOrUpdateResource(client))
+		}
 	}
 
 	// Register Helm tools
-	s.AddTool(tools.HelmListTool(), handlers.HelmList(helmClient))
-	s.AddTool(tools.HelmGetTool(), handlers.HelmGet(helmClient))
-	s.AddTool(tools.HelmHistoryTool(), handlers.HelmHistory(helmClient))
-	s.AddTool(tools.HelmRepoListTool(), handlers.HelmRepoList(helmClient))
+	if !noHelm {
+		s.AddTool(tools.HelmListTool(), handlers.HelmList(helmClient))
+		s.AddTool(tools.HelmGetTool(), handlers.HelmGet(helmClient))
+		s.AddTool(tools.HelmHistoryTool(), handlers.HelmHistory(helmClient))
+		s.AddTool(tools.HelmRepoListTool(), handlers.HelmRepoList(helmClient))
 
-	// Register write operations only if not in read-only mode
-	if !readOnly {
-		s.AddTool(tools.HelmInstallTool(), handlers.HelmInstall(helmClient))
-		s.AddTool(tools.HelmUpgradeTool(), handlers.HelmUpgrade(helmClient))
-		s.AddTool(tools.HelmUninstallTool(), handlers.HelmUninstall(helmClient))
-		s.AddTool(tools.HelmRollbackTool(), handlers.HelmRollback(helmClient))
-		s.AddTool(tools.HelmRepoAddTool(), handlers.HelmRepoAdd(helmClient))
+		// Register write operations only if not in read-only mode
+		if !readOnly {
+			s.AddTool(tools.HelmInstallTool(), handlers.HelmInstall(helmClient))
+			s.AddTool(tools.HelmUpgradeTool(), handlers.HelmUpgrade(helmClient))
+			s.AddTool(tools.HelmUninstallTool(), handlers.HelmUninstall(helmClient))
+			s.AddTool(tools.HelmRollbackTool(), handlers.HelmRollback(helmClient))
+			s.AddTool(tools.HelmRepoAddTool(), handlers.HelmRepoAdd(helmClient))
+		}
 	}
 
 	// Start server based on mode


### PR DESCRIPTION
I would really like to use this server with just Kubernetes tools. This PR adds flags which can be used to disable all Helm or all Kubernetes tools, minimizing the number of tools made available to models when not using Helm, for example.