### PR TITLE
new tool: CreateOrUpdateResourceYAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,10 +501,10 @@ Retrieves events for a specific namespace or resource.
 
 #### 9. `createOrUpdateResource`
 
-Creates a new resource or updates an existing one from a YAML or JSON manifest.
+Creates a new resource or updates an existing one from a JSON manifest.
 
 **Parameters:**
-- `manifest` (string, required): The YAML or JSON manifest of the resource.
+- `manifest` (string, required): The JSON manifest of the resource.
 - `namespace` (string, optional): The namespace in which to create/update the resource. If the manifest contains a namespace, this parameter can be used to override it. If not provided and the manifest doesn't specify one, "default" might be assumed or it might be an error depending on the resource type.
 
 **Example:**
@@ -524,12 +524,12 @@ Creates a new resource or updates an existing one from a YAML or JSON manifest.
 }
 
 ```
-#### `createOrUpdateResourceYAML`
+#### 10. `createOrUpdateResourceYAML`
 
 Creates a new resource or updates an existing one from a YAML manifest. This tool is specifically optimized for YAML input and provides better error handling for YAML parsing issues.
 
 **Parameters:**
-- `yamlManifest` (string, required): The YAML manifest of the resource.
+- `manifest` (string, required): The YAML manifest of the resource.
 - `namespace` (string, optional): The namespace in which to create/update the resource. If the manifest contains a namespace, this parameter can be used to override it. If not provided and the manifest doesn't specify one, "default" might be assumed or it might be an error depending on the resource type.
 - `kind` (string, optional): The kind of the resource. If not provided, the kind will be inferred from the YAML manifest.
 
@@ -543,7 +543,7 @@ Creates a new resource or updates an existing one from a YAML manifest. This too
     "name": "createOrUpdateResourceYAML",
     "arguments": {
       "namespace": "default",
-      "yamlManifest": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-new-pod\nspec:\n  containers:\n  - name: nginx\n    image: nginx:latest"
+      "manifest": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-new-pod\nspec:\n  containers:\n  - name: nginx\n    image: nginx:latest"
     }
   }
 }
@@ -552,7 +552,7 @@ Creates a new resource or updates an existing one from a YAML manifest. This too
 
 ### Helm Operations
 
-#### 10. `helmInstall`
+#### 11. `helmInstall`
 
 Install a Helm chart to the Kubernetes cluster.
 
@@ -587,27 +587,27 @@ Install a Helm chart to the Kubernetes cluster.
 }
 ```
 
-#### 11. `helmUpgrade`
+#### 12. `helmUpgrade`
 
 Upgrade an existing Helm release.
 
-#### 12. `helmUninstall`
+#### 13. `helmUninstall`
 
 Uninstall a Helm release from the Kubernetes cluster.
 
-#### 13. `helmList`
+#### 14. `helmList`
 
 List all Helm releases in the cluster or a specific namespace.
 
-#### 14. `helmGet`
+#### 15. `helmGet`
 
 Get details of a specific Helm release.
 
-#### 15. `helmHistory`
+#### 16. `helmHistory`
 
 Get the history of a Helm release.
 
-#### 16. `helmRollback`
+#### 17. `helmRollback`
 
 Rollback a Helm release to a previous revision.
 

--- a/README.md
+++ b/README.md
@@ -522,6 +522,31 @@ Creates a new resource or updates an existing one from a YAML or JSON manifest.
   }
 }
 ```
+#### `createOrUpdateResourceYAML`
+
+Creates a new resource or updates an existing one from a YAML manifest. This tool is specifically optimized for YAML input and provides better error handling for YAML parsing issues.
+
+**Parameters:**
+- `yamlManifest` (string, required): The YAML manifest of the resource.
+- `namespace` (string, optional): The namespace in which to create/update the resource. If the manifest contains a namespace, this parameter can be used to override it. If not provided and the manifest doesn't specify one, "default" might be assumed or it might be an error depending on the resource type.
+- `kind` (string, optional): The kind of the resource. If not provided, the kind will be inferred from the YAML manifest.
+
+**Example:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "createOrUpdateResourceYAML",
+    "arguments": {
+      "namespace": "default",
+      "yamlManifest": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-new-pod\nspec:\n  containers:\n  - name: nginx\n    image: nginx:latest"
+    }
+  }
+}
+
+```
 
 ### Helm Operations
 

--- a/handlers/k8s.go
+++ b/handlers/k8s.go
@@ -347,7 +347,7 @@ func CreateOrUpdateResourceYAML(client *k8s.Client) func(ctx context.Context, re
 			return nil, fmt.Errorf("invalid arguments type: expected map[string]interface{}")
 		}
 
-		yamlManifest, err := getRequiredStringArg(args, "yamlManifest")
+		yamlManifest, err := getRequiredStringArg(args, "manifest")
 		if err != nil {
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 		// Register write operations only if not in read-only mode
 		if !readOnly {
 			s.AddTool(tools.CreateOrUpdateResourceTool(), handlers.CreateOrUpdateResource(client))
+			s.AddTool(tools.CreateOrUpdateResourceYAMLTool(), handlers.CreateOrUpdateResourceYAML(client))
 		}
 	}
 

--- a/tools/k8s.go
+++ b/tools/k8s.go
@@ -1,4 +1,3 @@
-
 // Package tools provides MCP tool handlers for interacting with Kubernetes.
 package tools
 
@@ -122,5 +121,16 @@ func CreateOrUpdateResourceTool() mcp.Tool {
 		mcp.WithString("kind", mcp.Required(), mcp.Description("The type of resource to create")),
 		mcp.WithString("namespace", mcp.Description("The namespace of the resource")),
 		mcp.WithString("manifest", mcp.Required(), mcp.Description("The manifest of the resource to create")),
+	)
+}
+
+// CreateOrUpdateResourceYAMLTool creates a tool definition for creating/updating resources from YAML manifests
+func CreateOrUpdateResourceYAMLTool() mcp.Tool {
+	return mcp.NewTool(
+		"createResourceYAML",
+		mcp.WithDescription("Create or update a resource in the Kubernetes cluster from a YAML manifest. This tool is specifically optimized for YAML input and provides better error handling for YAML parsing issues."),
+		mcp.WithString("kind", mcp.Description("The type of resource to create (optional, will be inferred from YAML manifest if not provided)")),
+		mcp.WithString("namespace", mcp.Description("The namespace of the resource (overrides namespace in YAML manifest if provided)")),
+		mcp.WithString("yamlManifest", mcp.Required(), mcp.Description("The YAML manifest of the resource to create or update. Must be valid Kubernetes YAML format.")),
 	)
 }


### PR DESCRIPTION
## What's Changed

- Added `createOrUpdateResourceYAML` tool for YAML-specific Kubernetes resource creation/updates
- Updated README.md with comprehensive documentation for the new tool

## Why

The existing `createOrUpdateResource` tool works with JSON manifests, but many Kubernetes users prefer working with YAML format.

## How to Test

### JSON-RPC API Example
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/call",
  "params": {
    "name": "createOrUpdateResourceYAML",
    "arguments": {
      "namespace": "default",
      "yamlManifest": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: test-pod\nspec:\n  containers:\n  - name: nginx\n    image: nginx:latest"
    }
  }
}
```

## Breaking Changes

None. This is a purely additive change that maintains full backward compatibility.