### PR TITLE
feat: add deleteResource tool and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ A Kubernetes Model Context Protocol (MCP) server that provides tools for interac
 - **Pod Metrics**: Get CPU and Memory metrics for specific pods.
 - **Event Listing**: List events within a namespace or for a specific resource.
 - **Resource Creation/Updating**: Create new Kubernetes resources or update existing ones from a YAML or JSON manifest.
+- **Resource Deletion**: It deletes a resource in the Kubernetes cluster based on the provided namespace and kind.
 - **Standardized Interface**: Uses the MCP protocol for consistent tool interaction.
 - **Flexible Configuration**: Supports different Kubernetes contexts and resource scopes.
-- **Multiple Modes**: Run in `stdio` mode for CLI tools, `sse` mode, or `streamable-http` mode for web applications.
+- **Multiple Modes**: Run in `stdio` mode for CLI tools, `sse` mode, or `streamable-http` mode for web applications, and `--readonly` for no change in the cluster.
 - **Security**: Runs as non-root user in Docker containers for enhanced security.
 
 ## Prerequisites
@@ -544,6 +545,59 @@ Creates a new resource or updates an existing one from a YAML manifest. This too
     "arguments": {
       "namespace": "default",
       "manifest": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-new-pod\nspec:\n  containers:\n  - name: nginx\n    image: nginx:latest"
+    }
+  }
+}
+
+```
+
+#### 11. `createResourceYAML`
+
+Creates a new resource or updates an existing one from a YAML manifest. This tool is specifically optimized for YAML input and provides better error handling for YAML parsing issues.
+
+**Parameters:**
+- `yamlManifest` (string, required): The YAML manifest of the resource to create or update. Must be valid Kubernetes YAML format.
+- `namespace` (string, optional): The namespace of the resource (overrides namespace in YAML manifest if provided).
+- `kind` (string, optional): The type of resource to create (optional, will be inferred from YAML manifest if not provided).
+
+**Example:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "createResourceYAML",
+    "arguments": {
+      "namespace": "default",
+      "yamlManifest": "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-new-pod\nspec:\n  containers:\n  - name: nginx\n    image: nginx:latest"
+    }
+  }
+}
+
+```
+
+#### 12. `deleteResource`
+
+Deletes a specific resource from the Kubernetes cluster.
+
+**Parameters:**
+- `kind` (string, required): The type of resource to delete.
+- `name` (string, required): The name of the resource to delete.
+- `namespace` (string, optional): The namespace of the resource (required for namespaced resources).
+
+**Example:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "deleteResource",
+    "arguments": {
+      "kind": "Pod",
+      "name": "my-pod",
+      "namespace": "default"
     }
   }
 }

--- a/handlers/k8s.go
+++ b/handlers/k8s.go
@@ -368,3 +368,34 @@ func CreateOrUpdateResourceYAML(client *k8s.Client) func(ctx context.Context, re
 		return mcp.NewToolResultText(string(jsonResponse)), nil
 	}
 }
+
+// DeleteResource returns a handler function for the deleteResource tool.
+// It deletes a resource in the Kubernetes cluster based on the provided
+// namespace and kind. The result is serialized to JSON and returned.
+func DeleteResource(client *k8s.Client) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid arguments type: expected map[string]interface{}")
+		}
+
+		kind, err := getRequiredStringArg(args, "kind")
+		if err != nil {
+			return nil, err
+		}
+
+		name, err := getRequiredStringArg(args, "name")
+		if err != nil {
+			return nil, err
+		}
+
+		namespace := getStringArg(args, "namespace", "")
+
+		err = client.DeleteResource(ctx, kind, name, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to delete resource: %w", err)
+		}
+
+		return mcp.NewToolResultText("Resource deleted successfully"), nil
+	}
+}

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func main() {
 		if !readOnly {
 			s.AddTool(tools.CreateOrUpdateResourceJSONTool(), handlers.CreateOrUpdateResourceJSON(client))
 			s.AddTool(tools.CreateOrUpdateResourceYAMLTool(), handlers.CreateOrUpdateResourceYAML(client))
+			s.AddTool(tools.DeleteResourceTool(), handlers.DeleteResource(client))
 		}
 	}
 

--- a/tools/k8s.go
+++ b/tools/k8s.go
@@ -134,3 +134,14 @@ func CreateOrUpdateResourceYAMLTool() mcp.Tool {
 		mcp.WithString("yamlManifest", mcp.Required(), mcp.Description("The YAML manifest of the resource to create or update. Must be valid Kubernetes YAML format.")),
 	)
 }
+
+// DeleteResourceTool creates a tool definition for deleting resources
+func DeleteResourceTool() mcp.Tool {
+	return mcp.NewTool(
+		"deleteResource",
+		mcp.WithDescription("Delete a resource in the Kubernetes cluster"),
+		mcp.WithString("kind", mcp.Required(), mcp.Description("The type of resource to delete")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("The name of the resource to delete")),
+		mcp.WithString("namespace", mcp.Description("The namespace of the resource")),
+	)
+}


### PR DESCRIPTION
This commit introduces the deleteResource tool, allowing users to delete specific resources from the Kubernetes cluster. The main.go file is updated to register the new tool, and the README.md is enhanced to include details about the resource deletion functionality and its parameters.