### PR TITLE
feat(tools): add rolloutRestart tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,8 +523,8 @@ Creates a new resource or updates an existing one from a JSON manifest.
     }
   }
 }
-
 ```
+
 #### 10. `createOrUpdateResourceYAML`
 
 Creates a new resource or updates an existing one from a YAML manifest. This tool is specifically optimized for YAML input and provides better error handling for YAML parsing issues.
@@ -548,11 +548,51 @@ Creates a new resource or updates an existing one from a YAML manifest. This too
     }
   }
 }
-
 ```
 
+#### 11. `rolloutRestart`
 
-#### 11. `deleteResource`
+Triggers a rolling restart of a Kubernetes resource that supports spec.template.metadata.annotations. This includes Deployment, DaemonSet, StatefulSet, Job, and similar resources.
+
+**Parameters:**
+- `kind` (string, required): The kind of resource (e.g., "Deployment", "StatefulSet").
+- `name`: (string, required): The name of the resource to restart.
+- `namespace` (string, required for namespaced resources): The namespace of the resource.
+
+**Example (StatefulSet):**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "rolloutRestart",
+    "arguments": {
+      "kind": "StatefulSet",
+      "name": "redis-cluster-01",
+      "namespace": "default"
+    }
+  }
+}
+```
+**Example (Deployment):**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "rolloutRestart",
+    "arguments": {
+      "kind": "Deployment",
+      "name": "my-app-deployment",
+      "namespace": "default"
+    }
+  }
+}
+```
+
+#### 12. `deleteResource`
 
 Deletes a specific resource from the Kubernetes cluster.
 
@@ -576,12 +616,34 @@ Deletes a specific resource from the Kubernetes cluster.
     }
   }
 }
+```
 
+#### 13. `getIngresses`
+
+Retrieves ingress resources from the Kubernetes cluster.
+You can filter ingresses by host. If no host is provided, all ingresses are returned.
+
+**Parameters:**
+- `host` (string, optional): The host to filter ingresses by. If omitted, all ingresses are included.
+
+**Example:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "getIngresses",
+    "arguments": {
+      "host": "example.com"
+    }
+  }
+}
 ```
 
 ### Helm Operations
 
-#### 12. `helmInstall`
+#### 14. `helmInstall`
 
 Install a Helm chart to the Kubernetes cluster.
 
@@ -616,7 +678,7 @@ Install a Helm chart to the Kubernetes cluster.
 }
 ```
 
-#### 13. `helmUpgrade`
+#### 15. `helmUpgrade`
 
 Upgrade an existing Helm release.
 
@@ -648,26 +710,25 @@ Upgrade an existing Helm release.
     }
   }
 }
-
 ```
 
-#### 14. `helmList`
+#### 16. `helmList`
 
 List all Helm releases in the cluster or a specific namespace.
 
-#### 15. `helmGet`
+#### 17. `helmGet`
 
 Get details of a specific Helm release.
 
-#### 16. `helmHistory`
+#### 18. `helmHistory`
 
 Get the history of a Helm release.
 
-#### 17. `helmRollback`
+#### 19. `helmRollback`
 
 Rollback a Helm release to a previous revision.
 
-#### 18. `helmUninstall`
+#### 20. `helmUninstall`
 
 Uninstall a Helm release from the Kubernetes cluster.
 

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,17 @@
 module github.com/reza-gholizade/k8s-mcp-server
 
-go 1.24.1
+go 1.24.0
+
+toolchain go1.24.6
 
 require (
-	github.com/mark3labs/mcp-go v0.38.0
+	github.com/mark3labs/mcp-go v0.39.0
 	helm.sh/helm/v3 v3.18.6
 	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/client-go v0.34.0
+	k8s.io/metrics v0.34.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -29,14 +33,25 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/evanphx/json-patch v5.9.11+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
@@ -46,11 +61,14 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
@@ -59,75 +77,56 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rubenv/sql-migrate v1.8.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
+	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
-	google.golang.org/grpc v1.68.1 // indirect
-	k8s.io/apiextensions-apiserver v0.33.3 // indirect
-	k8s.io/apiserver v0.33.3 // indirect
-	k8s.io/cli-runtime v0.33.3 // indirect
-	k8s.io/component-base v0.33.3 // indirect
-	k8s.io/kubectl v0.33.3 // indirect
-	oras.land/oras-go/v2 v2.6.0 // indirect
-	sigs.k8s.io/kustomize/api v0.19.0 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.19.0 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.2 // indirect
-	github.com/go-openapi/jsonpointer v0.21.0 // indirect
-	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/spf13/cast v1.7.1 // indirect
-	github.com/spf13/pflag v1.0.7 // indirect
-	github.com/x448/float16 v0.8.4 // indirect
-	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/term v0.33.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20241209162323-e6fa225c2576 // indirect
+	google.golang.org/grpc v1.68.1 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiextensions-apiserver v0.33.3 // indirect
+	k8s.io/apiserver v0.33.3 // indirect
+	k8s.io/cli-runtime v0.33.3 // indirect
+	k8s.io/component-base v0.33.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
-	k8s.io/metrics v0.34.0
+	k8s.io/kubectl v0.33.3 // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
+	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
-	sigs.k8s.io/yaml v1.6.0
+	sigs.k8s.io/kustomize/api v0.19.0 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.19.0 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.38.0 h1:E5tmJiIXkhwlV0pLAwAT0O5ZjUZSISE/2Jxg+6vpq4I=
-github.com/mark3labs/mcp-go v0.38.0/go.mod h1:T7tUa2jO6MavG+3P25Oy/jR7iCeJPHImCZHRymCn39g=
+github.com/mark3labs/mcp-go v0.39.0 h1:dQwaOADzUJ1ROslEJB8QV+4u/8XQCqH9ylB//x8cCEQ=
+github.com/mark3labs/mcp-go v0.39.0/go.mod h1:T7tUa2jO6MavG+3P25Oy/jR7iCeJPHImCZHRymCn39g=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=

--- a/handlers/k8s.go
+++ b/handlers/k8s.go
@@ -426,3 +426,34 @@ func GetIngresses(client *k8s.Client) func(ctx context.Context, request mcp.Call
 		return mcp.NewToolResultText(string(jsonResponse)), nil
 	}
 }
+
+// RolloutRestartHandler returns a handler function for the rolloutRestart tool.
+// It calls the Client.RolloutRestart method and serializes the result to JSON.
+func RolloutRestart(client *k8s.Client) func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		args, ok := request.Params.Arguments.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid arguments type: expected map[string]interface{}")
+		}
+
+		kind := getStringArg(args, "kind", "")
+		name := getStringArg(args, "name", "")
+		namespace := getStringArg(args, "namespace", "")
+
+		if kind == "" || name == "" || namespace == "" {
+			return nil, fmt.Errorf("kind, name, and namespace are required")
+		}
+
+		result, err := client.RolloutRestart(ctx, kind, name, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to rollout restart resource: %w", err)
+		}
+
+		jsonResponse, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize response: %w", err)
+		}
+
+		return mcp.NewToolResultText(string(jsonResponse)), nil
+	}
+}

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 			s.AddTool(tools.CreateOrUpdateResourceJSONTool(), handlers.CreateOrUpdateResourceJSON(client))
 			s.AddTool(tools.CreateOrUpdateResourceYAMLTool(), handlers.CreateOrUpdateResourceYAML(client))
 			s.AddTool(tools.DeleteResourceTool(), handlers.DeleteResource(client))
+			s.AddTool(tools.RolloutRestartTool(), handlers.RolloutRestart(client))
 		}
 	}
 

--- a/tools/k8s.go
+++ b/tools/k8s.go
@@ -156,3 +156,14 @@ func GetIngressesTool() mcp.Tool {
 		mcp.WithString("host", mcp.Required(), mcp.Description("The host to get ingresses from")),
 	)
 }
+
+// RolloutRestartTool creates a tool for restarting workloads with pod templates.
+func RolloutRestartTool() mcp.Tool {
+	return mcp.NewTool(
+		"rolloutRestart",
+		mcp.WithDescription("Perform a rollout restart on a Deployment, DaemonSet, StatefulSet, ReplicaSet, or any resource with spec.template."),
+		mcp.WithString("kind", mcp.Required(), mcp.Description("The type of resource to restart (e.g., Deployment, DaemonSet)")),
+		mcp.WithString("name", mcp.Required(), mcp.Description("The name of the resource")),
+		mcp.WithString("namespace", mcp.Required(), mcp.Description("The namespace of the resource")),
+	)
+}


### PR DESCRIPTION
## Add `rolloutRestart` Tool  

This PR adds a new tool **`rolloutRestart`** to restart Kubernetes workloads by patching `spec.template.metadata.annotations`, similar to `kubectl rollout restart`.  

### Changes  
- Implemented `rolloutRestart` tool  
- Supports **Deployment**, **StatefulSet**, **DaemonSet** (and similar `spec.template` resources)  
- Updated README with usage examples  

### Examples  

**Deployment**  
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "tools/call",
  "params": {
    "name": "rolloutRestart",
    "arguments": {
      "kind": "Deployment",
      "name": "my-app-deployment",
      "namespace": "default"
    }
  }
}
```

## Related Issue
Closed https://github.com/reza-gholizade/k8s-mcp-server/issues/42