### PR TITLE
Secure MCP HTTP transports by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG TARGETARCH
 
 # Build the Go app with cross-compilation support
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
-    go build -ldflags="-w -s" -o k8s-mcp-server main.go
+    go build -ldflags="-w -s" -o k8s-mcp-server .
 
 # Use a minimal base image instead of scratch for better compatibility
 FROM alpine:3.21
@@ -49,13 +49,9 @@ USER appuser
 # Expose the port the app runs on
 EXPOSE 8080
 
-# Set default environment variables
-ENV SERVER_MODE=sse
+# Default to the local-process transport. HTTP modes require explicit opt-in.
+ENV SERVER_MODE=stdio
 ENV SERVER_PORT=8080
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/ || exit 1
 
 # Command to run the executable
 ENTRYPOINT ["/usr/local/bin/k8s-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/reza-g
 
 3.  **Build the server:**
     ```bash
-    go build -o k8s-mcp-server main.go
+    go build -o k8s-mcp-server .
     ```
 
 ## Usage
@@ -67,37 +67,45 @@ SERVER_MODE=stdio ./k8s-mcp-server
 #### SSE Mode (for web applications)
 This mode starts an HTTP server with Server-Sent Events support.
 
-Default (port 8080):
+HTTP transports require a bearer token and listen on loopback by default:
+
 ```bash
-./k8s-mcp-server --mode sse
+MCP_AUTH_TOKEN="$(openssl rand -hex 32)" ./k8s-mcp-server --mode sse
 ```
 Specify a port:
 ```bash
-./k8s-mcp-server --mode sse --port 9090
+MCP_AUTH_TOKEN="your-random-secret" ./k8s-mcp-server --mode sse --port 9090
 ```
 Or using environment variables:
 ```bash
-SERVER_MODE=sse SERVER_PORT=9090 ./k8s-mcp-server
+SERVER_MODE=sse SERVER_PORT=9090 MCP_AUTH_TOKEN="your-random-secret" ./k8s-mcp-server
 ```
 #### Streamable-HTTP Mode (for web applications)
 This mode starts an HTTP server with streamable-http transport support, following the MCP specification.
 
 Default (port 8080):
 ```bash
-./k8s-mcp-server --mode streamable-http
+MCP_AUTH_TOKEN="your-random-secret" ./k8s-mcp-server --mode streamable-http
 ```
 Specify a port:
 ```bash
-./k8s-mcp-server --mode streamable-http --port 9090
+MCP_AUTH_TOKEN="your-random-secret" ./k8s-mcp-server --mode streamable-http --port 9090
 ```
 Or using environment variables:
 ```bash
-SERVER_MODE=streamable-http SERVER_PORT=9090 ./k8s-mcp-server
+SERVER_MODE=streamable-http SERVER_PORT=9090 MCP_AUTH_TOKEN="your-random-secret" ./k8s-mcp-server
 ```
 
 The server will be available at `http://localhost:8080/mcp` (or your specified port).
 
-If no mode is specified, it defaults to SSE on port 8080.
+If no mode is specified, the server defaults to `stdio`. HTTP modes bind to
+`127.0.0.1` by default. Set `SERVER_HOST=0.0.0.0` (or `--host 0.0.0.0`) only
+when network access is intentional, and send `Authorization: Bearer <token>`
+on every MCP request. Browser clients must also be explicitly allowed with a
+comma-separated `MCP_ALLOWED_ORIGINS` value.
+
+The unauthenticated `/healthz` endpoint is available for container health checks;
+it does not expose MCP functionality.
 
 ### Kubernetes Authentication
 
@@ -424,6 +432,13 @@ The Docker image runs as a non-root user (`appuser` with UID 1001) for enhanced 
 - The kubeconfig should be mounted to `/home/appuser/.kube/config`
 - Health checks are enabled to monitor container status
 - The container includes minimal dependencies (ca-certificates and curl only)
+
+SSE and streamable HTTP are fail-closed unless `MCP_AUTH_TOKEN` is set. Never
+publish an HTTP transport without authentication. Prefer `stdio` for local MCP
+clients, use `--read-only` where possible, and grant the server's Kubernetes
+identity only the RBAC permissions it needs. A session ID is not an authentication
+credential. Put remotely accessible deployments behind TLS and an authenticating
+reverse proxy, and configure `MCP_ALLOWED_ORIGINS` for browser-based clients.
 
 #### Making API Calls (SSE/Streamable-HTTP Mode)
 Once the server is running in SSE or streamable-http mode, you can make JSON-RPC calls to its HTTP endpoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,10 @@ services:
       
       # Server configuration
       - SERVER_MODE=sse # Explicitly set server mode (stdio, sse, or streamable-http)
+      - SERVER_HOST=0.0.0.0 # Explicit opt-in for container network access
       - SERVER_PORT=8080 # Explicitly set server port for SSE mode
+      - MCP_AUTH_TOKEN=${MCP_AUTH_TOKEN:?MCP_AUTH_TOKEN must be set}
+      # - MCP_ALLOWED_ORIGINS=https://your-client.example
     # command: ["--read-only"] # Uncomment to enable read-only mode
     # command: ["--no-k8s"] # Uncomment to disable Kubernetes tools
     # command: ["--no-helm"] # Uncomment to disable Helm tools
@@ -46,7 +49,7 @@ services:
     restart: unless-stopped
     healthcheck:
       # Ensure 'curl' is installed in your Docker image (e.g., RUN apk --no-cache add curl in Dockerfile)
-      test: ["CMD", "curl", "-f", "-s", "http://localhost:8080/"] # Check if the server responds on the root path
+      test: ["CMD", "curl", "-f", "-s", "http://localhost:8080/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/http_security.go
+++ b/http_security.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// secureMCPHandler protects every MCP HTTP endpoint. Session IDs are routing
+// identifiers and must never be treated as authentication credentials.
+func secureMCPHandler(next http.Handler, token string, allowedOrigins []string) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, origin := range allowedOrigins {
+		allowed[origin] = struct{}{}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin != "" {
+			if _, ok := allowed[origin]; !ok {
+				http.Error(w, "origin not allowed", http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Add("Vary", "Origin")
+		}
+
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, MCP-Session-Id, Last-Event-ID")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		provided := strings.TrimSpace(r.Header.Get("Authorization"))
+		const prefix = "Bearer "
+		if !strings.HasPrefix(provided, prefix) || !constantTimeEqual(strings.TrimSpace(strings.TrimPrefix(provided, prefix)), token) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="k8s-mcp-server"`)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func constantTimeEqual(provided, expected string) bool {
+	if len(provided) != len(expected) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) == 1
+}

--- a/http_security_test.go
+++ b/http_security_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecureMCPHandlerRequiresBearerToken(t *testing.T) {
+	called := false
+	handler := secureMCPHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusAccepted)
+	}), "secret", nil)
+
+	for _, auth := range []string{"", "Bearer wrong"} {
+		req := httptest.NewRequest(http.MethodPost, "/message?sessionId=test", nil)
+		req.Header.Set("Authorization", auth)
+		res := httptest.NewRecorder()
+		handler.ServeHTTP(res, req)
+		if res.Code != http.StatusUnauthorized {
+			t.Fatalf("authorization %q: got status %d, want %d", auth, res.Code, http.StatusUnauthorized)
+		}
+	}
+	if called {
+		t.Fatal("protected handler was called without valid authentication")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/message?sessionId=test", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusAccepted || !called {
+		t.Fatalf("valid token: got status %d, handler called=%v", res.Code, called)
+	}
+}
+
+func TestSecureMCPHandlerRejectsUntrustedOrigin(t *testing.T) {
+	handler := secureMCPHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), "secret", []string{"https://trusted.example"})
+
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Origin", "https://attacker.example")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("got status %d, want %d", res.Code, http.StatusForbidden)
+	}
+}
+
+func TestSecureMCPHandlerAllowsConfiguredOriginPreflight(t *testing.T) {
+	handler := secureMCPHandler(http.NotFoundHandler(), "secret", []string{"https://trusted.example"})
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	req.Header.Set("Origin", "https://trusted.example")
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("got status %d, want %d", res.Code, http.StatusNoContent)
+	}
+	if got := res.Header().Get("Access-Control-Allow-Origin"); got != "https://trusted.example" {
+		t.Fatalf("got Access-Control-Allow-Origin %q", got)
+	}
+}
+
+func TestHTTPSecurityConfigFailsClosed(t *testing.T) {
+	t.Setenv("MCP_AUTH_TOKEN", "")
+	if _, _, err := httpSecurityConfig(); err == nil {
+		t.Fatal("expected missing MCP_AUTH_TOKEN to fail")
+	}
+
+	t.Setenv("MCP_AUTH_TOKEN", "too-short")
+	if _, _, err := httpSecurityConfig(); err == nil {
+		t.Fatal("expected short MCP_AUTH_TOKEN to fail")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/reza-gholizade/k8s-mcp-server/handlers"
 	"github.com/reza-gholizade/k8s-mcp-server/pkg/helm"
@@ -27,13 +31,15 @@ import (
 func main() {
 	// Parse command line flags
 	var mode string
+	var host string
 	var port string
 	var readOnly bool
 	var noK8s bool
 	var noHelm bool
 
 	flag.StringVar(&port, "port", getEnvOrDefault("SERVER_PORT", "8080"), "Server port")
-	flag.StringVar(&mode, "mode", getEnvOrDefault("SERVER_MODE", "sse"), "Server mode: 'stdio', 'sse', or 'streamable-http'")
+	flag.StringVar(&host, "host", getEnvOrDefault("SERVER_HOST", "127.0.0.1"), "HTTP listen host")
+	flag.StringVar(&mode, "mode", getEnvOrDefault("SERVER_MODE", "stdio"), "Server mode: 'stdio', 'sse', or 'streamable-http'")
 	flag.BoolVar(&readOnly, "read-only", false, "Enable read-only mode (disables write operations)")
 	flag.BoolVar(&noK8s, "no-k8s", false, "Disable Kubernetes tools")
 	flag.BoolVar(&noHelm, "no-helm", false, "Disable Helm tools")
@@ -125,25 +131,65 @@ func main() {
 			return
 		}
 	case "sse":
-		fmt.Printf("Starting server in SSE mode on port %s...\n", port)
+		token, allowedOrigins, err := httpSecurityConfig()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Refusing to start SSE server: %v\n", err)
+			os.Exit(1)
+		}
+		addr := net.JoinHostPort(host, port)
+		fmt.Printf("Starting authenticated SSE server on %s...\n", addr)
 		sse := server.NewSSEServer(s)
-		if err := sse.Start(":" + port); err != nil {
+		if err := serveHTTP(addr, secureMCPHandler(sse, token, allowedOrigins)); err != nil {
 			fmt.Printf("Failed to start SSE server: %v\n", err)
 			return
 		}
-		fmt.Printf("SSE server started on port %s\n", port)
 	case "streamable-http":
-		fmt.Printf("Starting server in streamable-http mode on port %s...\n", port)
+		token, allowedOrigins, err := httpSecurityConfig()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Refusing to start streamable-http server: %v\n", err)
+			os.Exit(1)
+		}
+		addr := net.JoinHostPort(host, port)
+		fmt.Printf("Starting authenticated streamable-http server on %s...\n", addr)
 		streamableHTTP := server.NewStreamableHTTPServer(s, server.WithStateLess(true))
-		if err := streamableHTTP.Start(":" + port); err != nil {
+		if err := serveHTTP(addr, secureMCPHandler(streamableHTTP, token, allowedOrigins)); err != nil {
 			fmt.Printf("Failed to start streamable-http server: %v\n", err)
 			return
 		}
-		fmt.Printf("Streamable-http server started on port %s (endpoint: http://localhost:%s/mcp)\n", port, port)
 	default:
 		fmt.Printf("Unknown server mode: %s. Use 'stdio', 'sse', or 'streamable-http'.\n", mode)
 		return
 	}
+}
+
+func httpSecurityConfig() (string, []string, error) {
+	token := strings.TrimSpace(os.Getenv("MCP_AUTH_TOKEN"))
+	if len(token) < 32 {
+		return "", nil, fmt.Errorf("MCP_AUTH_TOKEN must contain at least 32 characters for HTTP transports")
+	}
+
+	var allowedOrigins []string
+	for _, origin := range strings.Split(os.Getenv("MCP_ALLOWED_ORIGINS"), ",") {
+		if origin = strings.TrimSpace(origin); origin != "" {
+			allowedOrigins = append(allowedOrigins, origin)
+		}
+	}
+	return token, allowedOrigins, nil
+}
+
+func serveHTTP(addr string, handler http.Handler) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.Handle("/", handler)
+
+	httpServer := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return httpServer.ListenAndServe()
 }
 
 // getEnvOrDefault returns the value of the environment variable or the default value if not set


### PR DESCRIPTION
## What changed

- require a minimum 32-character `MCP_AUTH_TOKEN` for SSE and streamable HTTP
- enforce bearer authentication before every MCP HTTP endpoint
- reject untrusted browser origins and support an explicit `MCP_ALLOWED_ORIGINS` allowlist
- bind HTTP transports to `127.0.0.1` by default with explicit `SERVER_HOST` opt-in
- change the default transport to `stdio`
- expose only `/healthz` without authentication
- add security middleware unit tests
- update Docker and deployment documentation

## Root cause

The HTTP transports were started directly with no authentication middleware. SSE also bound to all interfaces and was the default transport, while write-capable Kubernetes and Helm tools were enabled by default.

## Security impact

Unauthenticated network clients could enumerate and invoke MCP tools with the Kubernetes privileges configured for the server. The change makes HTTP startup fail closed and protects both affected HTTP transports.

## Validation

- `git diff --check`
- unit tests added for missing/invalid bearer tokens, trusted/untrusted origins, CORS preflight, and fail-closed token configuration
- local Go toolchain was unavailable; repository CI should run the full Go test/build suite

Fixes #131

Credit: @bebold6133